### PR TITLE
Utiliser les noms d'hôtes Docker au lieu des IP statiques

### DIFF
--- a/ACCESS_GUIDE.md
+++ b/ACCESS_GUIDE.md
@@ -29,11 +29,11 @@ The main entry point for the application is the **Policy Enforcement Point (PEP)
 
 - **Open your web browser and navigate to:**
   ```
-  http://172.25.0.40
+  http://pep
   ```
 
 - **⚠️ IMPORTANT:**
-  - **Do NOT use `localhost:5000`**. The system is intentionally configured to reject requests from `localhost` to protect against CSRF attacks. You must use the service's static IP address.
+  - **Do NOT use `localhost:5000`**. The system is intentionally configured to reject requests from `localhost` to protect against CSRF attacks. You must use the service's Docker name (e.g., `http://pep`).
   - If you are running Docker on a remote machine, ensure you can access the `172.25.0.0/24` subnet.
 
 ### **Step 3: Authenticate**
@@ -64,14 +64,14 @@ Here are solutions to common issues you might encounter.
 ### **Issue: "Internal Server Error" or "403 Forbidden" on `http://172.25.0.40`**
 
 - **Cause**: This is the expected behavior if you try to access the application from `localhost` or an untrusted IP address. The security policies (CSRF, IP whitelisting) are correctly blocking the request.
-- **✅ Solution**: Ensure you are using the correct IP address: `http://172.25.0.40`.
+- **✅ Solution**: Ensure you are using the correct Docker service name: `http://pep`.
 
 ### **Issue: "Login error: failed to connect: LDAP Result Code 200..."**
 
 - **Cause**: The Dex container cannot establish a connection with the OpenLDAP container.
 - **✅ Solution**:
   1.  **Check Container Status**: Ensure all containers are running with `docker compose ps`.
-  2.  **Verify Network**: Confirm that the `dex-server` and `ldap-server` are on the same `secure-network`.
+  2.  **Verify Network**: Confirm that the `dex-server` and `ldap-server` are on the same `backend-network`.
   3.  **Check Logs**: Review the logs for both services for more detailed errors:
       ```bash
       docker compose logs dex-server

--- a/NETWORK_ARCHITECTURE.md
+++ b/NETWORK_ARCHITECTURE.md
@@ -4,21 +4,19 @@
 
 This project implements a **3-tier network segmentation** architecture following Zero Trust principles, isolating services by function and security level.
 
-```
-172.25.0.0/16 (Docker Global Network)
-├── 172.25.0.0/24 (External/DMZ Network)
-│   ├── 172.25.0.30 - Apache Reverse Proxy (Entry Point)
-│   └── 172.25.0.40 - PEP (User Interface)
+Docker Network (DNS-based)
+├── external-network
+│   ├── apache-reverse-proxy - Apache Reverse Proxy (Entry Point)
+│   └── pep - PEP (User Interface)
 │
-├── 172.25.1.0/24 (Backend/Infrastructure Network - ISOLATED)
-│   ├── 172.25.1.10 - OpenLDAP (Identity Store - INTERNAL ONLY)
-│   ├── 172.25.1.20 - Dex (OIDC Provider - INTERNAL ONLY)
-│   └── 172.25.1.30 - Apache Proxy (Backend Interface)
+├── backend-network
+│   ├── ldap-server - OpenLDAP (Identity Store - INTERNAL ONLY)
+│   ├── dex-server - Dex (OIDC Provider - INTERNAL ONLY)
+│   └── apache-reverse-proxy - Apache Proxy (Backend Interface)
 │
-└── 172.25.2.0/24 (Application Network - ISOLATED)
-    ├── 172.25.2.40 - PEP (App Interface)
-    └── 172.25.2.50 - Flask Application (Business Logic)
-```
+└── app-network
+    ├── pep - PEP (App Interface)
+    └── flask-application - Flask Application (Business Logic)
 
 ## Network Configuration
 
@@ -74,11 +72,11 @@ Authentication → Backend Network (Dex) → Backend Network (LDAP)
 
 | From Service | To Service | Network Path | Purpose | Internet Access |
 |--------------|------------|--------------|---------|-----------------|
-| **User** | PEP | External → External | Web Interface | ✅ Yes |
-| **PEP** | Apache Proxy | External → External | OAuth2 Auth | ✅ Yes |
-| **Apache Proxy** | Dex | External → Backend | OIDC Endpoints | ❌ Internal Only |
-| **Dex** | LDAP | Backend → Backend | User Validation | ❌ Internal Only |
-| **PEP** | Flask | External → Application | App Requests | ❌ Internal Only |
+| **User** | PEP (pep) | External → External | Web Interface | ✅ Yes |
+| **PEP** | Apache Proxy (apache-reverse-proxy) | External → External | OAuth2 Auth | ✅ Yes |
+| **Apache Proxy** | Dex (dex-server) | External → Backend | OIDC Endpoints | ❌ Internal Only |
+| **Dex** | LDAP (ldap-server) | Backend → Backend | User Validation | ❌ Internal Only |
+| **PEP** | Flask (flask-application) | External → Application | App Requests | ❌ Internal Only |
 
 ## Docker Compose Networks
 
@@ -176,3 +174,5 @@ From the previous configuration with exposed LDAP ports to this secured setup:
 2. **LDAP Access Logs**: Log all LDAP queries for anomaly detection
 3. **Failed Authentication Monitoring**: Track authentication failures
 4. **Network Boundary Alerts**: Alert on unexpected network access attempts
+
+**Note:** All service communication now uses Docker DNS names (service names) instead of static IP addresses. This improves maintainability and flexibility.

--- a/PEP/oidc.conf
+++ b/PEP/oidc.conf
@@ -1,15 +1,15 @@
 # OIDC Configuration with Zero Trust Security - ANSSI compliant
 OIDCClientID flask-app
 OIDCClientSecret flask-app-secret
-OIDCRedirectURI http://172.25.0.40/oauth2callback
+OIDCRedirectURI http://pep/oauth2callback
 
 # Manual endpoint configuration with IP-based routing
-OIDCProviderIssuer http://172.25.0.30
-OIDCProviderAuthorizationEndpoint http://172.25.0.30/auth
-OIDCProviderTokenEndpoint http://172.25.1.20:5556/token
+OIDCProviderIssuer http://apache-reverse-proxy
+OIDCProviderAuthorizationEndpoint http://apache-reverse-proxy/auth
+OIDCProviderTokenEndpoint http://dex-server:5556/token
 OIDCProviderTokenEndpointAuth client_secret_post
-OIDCProviderUserInfoEndpoint http://172.25.1.20:5556/userinfo
-OIDCProviderJwksUri http://172.25.1.20:5556/keys
+OIDCProviderUserInfoEndpoint http://dex-server:5556/userinfo
+OIDCProviderJwksUri http://dex-server:5556/keys
 
 # Security configurations
 OIDCScope "openid email profile groups"
@@ -46,13 +46,13 @@ Header always set Referrer-Policy "strict-origin-when-cross-origin"
     RequestHeader set X-Real-IP %{REMOTE_ADDR}s
     
     # CORS headers for secure communication
-    Header always set Access-Control-Allow-Origin "http://172.25.0.40"
+    Header always set Access-Control-Allow-Origin "http://pep"
     Header always set Access-Control-Allow-Credentials "true"
     Header always set Access-Control-Allow-Methods "GET, POST, OPTIONS"
 
     # Proxy to Flask backend with IP-based routing (Application Network)
-    ProxyPass http://172.25.2.50:8080/
-    ProxyPassReverse http://172.25.2.50:8080/
+    ProxyPass http://flask-application:8080/
+    ProxyPassReverse http://flask-application:8080/
     
     # Security: Remove sensitive headers before forwarding
     RequestHeader unset Authorization

--- a/PRESENTATION.md
+++ b/PRESENTATION.md
@@ -8,18 +8,18 @@ This project implements an OAuth2 Policy Enforcement Point (PEP) with 3-tier net
 
 ```mermaid
 graph TB
-    subgraph "172.25.0.0/24 - External Network"
-        PEP[PEP .40]
-        Apache[Apache .30]
+    subgraph "external-network"
+        PEP[pep]
+        Apache[apache-reverse-proxy]
     end
     
-    subgraph "172.25.1.0/24 - Backend Network (Internal)"
-        LDAP[LDAP .10:389]
-        Dex[Dex OIDC .20]
+    subgraph "backend-network"
+        LDAP[ldap-server:389]
+        Dex[dex-server]
     end
     
-    subgraph "172.25.2.0/24 - Application Network (Internal)"
-        Flask[Flask App .50]
+    subgraph "app-network"
+        Flask[flask-application]
     end
     
     User --> PEP
@@ -94,18 +94,18 @@ sequenceDiagram
 
 | Service | Purpose | Network | Internet Access | Exposed Ports |
 |---------|---------|---------|----------------|---------------|
-| PEP | Authentication gateway | External | Yes | 5000 |
-| Apache | Reverse proxy | External | Yes | 80 |
-| Dex | OIDC provider | Backend | No | None |
-| LDAP | User directory | Backend | No | None |
-| Flask | Business application | Application | No | None |
+| PEP (pep) | Authentication gateway | External | Yes | 5000 |
+| Apache (apache-reverse-proxy) | Reverse proxy | External | Yes | 80 |
+| Dex (dex-server) | OIDC provider | Backend | No | None |
+| LDAP (ldap-server) | User directory | Backend | No | None |
+| Flask (flask-application) | Business application | Application | No | None |
 
 **Justification**: Only external network services have exposed ports in docker-compose.yml. Backend services use `expose:` instead of `ports:`, preventing external access.
 
 ## Implementation Details
 
 ### OIDC Configuration
-- **Provider**: Dex at `http://172.25.1.20`
+- **Provider**: Dex at `http://dex-server`
 - **Client**: `flask-app` with secret `flask-app-secret`
 - **Scopes**: `openid email profile groups`
 - **Token endpoint**: Internal network communication
@@ -136,15 +136,17 @@ The backend network isolation can be verified:
 docker network inspect idp-backend | grep '"Internal": true'
 
 # Verify LDAP not accessible externally
-curl http://172.25.1.10    # Couldn't connect to server
+curl http://ldap-server:389    # Should connect from inside Docker network
 curl http://localhost:389  # Couldn't connect to server
 
 # Verify Dex not accessible externally  
-curl http://172.25.1.20    # Couldn't connect to server
+curl http://dex-server:5556    # Should connect from inside Docker network
 curl http://localhost:5556  # Couldn't connect to server
 ```
 
 **Justification**: Commands above demonstrate that backend services are not accessible from the host, proving network isolation works.
+
+**Note:** All service communication now uses Docker DNS names (service names) instead of static IP addresses. This improves maintainability and flexibility.
 
 ## Key Benefits
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ A containerized OAuth2 Policy Enforcement Point (PEP) implementing 3-tier networ
 docker compose up -d
 
 # Access the application with terminal
-curl -L http://172.25.0.40
+curl -L http://pep
 
 # Access the application with your browser
-Open your web browser and navigate to the IP address of the PEP service (e.g., `http://172.25.0.40`).
+Open your web browser and navigate to the PEP service using its Docker name (e.g., `http://pep`).
 
 ```
 
@@ -31,11 +31,11 @@ Open your web browser and navigate to the IP address of the PEP service (e.g., `
 
 | Service | Network | Ports | Description |
 |---------|---------|-------|-------------|
-| PEP | External | 5000 | OAuth2 Policy Enforcement Point |
-| Apache | External | 80 | Reverse proxy for Dex |
-| Dex | Backend | 5556 | OIDC identity provider |
-| LDAP | Backend | 389 | User directory |
-| Flask | Application | 8080 | Protected application |
+| PEP (pep) | External | 5000 | OAuth2 Policy Enforcement Point |
+| Apache (apache-reverse-proxy) | External | 80 | Reverse proxy for Dex |
+| Dex (dex-server) | Backend | 5556 | OIDC identity provider |
+| LDAP (ldap-server) | Backend | 389 | User directory |
+| Flask (flask-application) | Application | 8080 | Protected application |
 
 ## Configuration
 
@@ -45,7 +45,7 @@ Open your web browser and navigate to the IP address of the PEP service (e.g., `
 - **LDAP**: Ports not exposed to host (accessible only within backend network)
 
 ### OIDC Configuration
-- **Provider**: Dex at `http://172.25.1.20` - no internet access
+- **Provider**: Dex at `http://dex-server` - no internet access
 - **Client ID**: `flask-app`
 - **Scopes**: `openid email profile groups`
 - **Session timeout**: 30 minutes inactivity
@@ -60,7 +60,8 @@ docker compose logs -f <service>
 docker compose ps
 
 # Access LDAP for debugging
-docker exec ldap-server ldapsearch -x -b "dc=example,dc=org"
+curl http://ldap-server:389    # Should connect from inside Docker network
+curl http://dex-server:5556    # Should connect from inside Docker network
 ```
 
 ## Security Implementation

--- a/apache-proxy/apache.conf
+++ b/apache-proxy/apache.conf
@@ -46,11 +46,11 @@ TypesConfig conf/mime.types
 
 # Main virtual host with strict access control
 <VirtualHost *:80>
-    ServerName 172.25.0.30
+    ServerName apache-reverse-proxy
     DocumentRoot /usr/local/apache2/htdocs
     
     # CORS Policy - Strict origin control
-    Header always set Access-Control-Allow-Origin "http://172.25.0.40"
+    Header always set Access-Control-Allow-Origin "http://pep"
     Header always set Access-Control-Allow-Methods "GET, POST, OPTIONS"
     Header always set Access-Control-Allow-Headers "Content-Type, Authorization, X-Requested-With"
     Header always set Access-Control-Allow-Credentials "true"
@@ -62,21 +62,21 @@ TypesConfig conf/mime.types
     ProxyPreserveHost On
     ProxyRequests Off
     
-    # Proxy everything to Dex with IP-based routing (Backend Network)
-    ProxyPass /static/ http://172.25.1.20:5556/static/
-    ProxyPassReverse /static/ http://172.25.1.20:5556/static/
-    ProxyPass /theme/ http://172.25.1.20:5556/theme/
-    ProxyPassReverse /theme/ http://172.25.1.20:5556/theme/
-    ProxyPass /.well-known/ http://172.25.1.20:5556/.well-known/
-    ProxyPassReverse /.well-known/ http://172.25.1.20:5556/.well-known/
-    ProxyPass /auth http://172.25.1.20:5556/auth
-    ProxyPassReverse /auth http://172.25.1.20:5556/auth
-    ProxyPass /token http://172.25.1.20:5556/token
-    ProxyPassReverse /token http://172.25.1.20:5556/token
-    ProxyPass /userinfo http://172.25.1.20:5556/userinfo
-    ProxyPassReverse /userinfo http://172.25.1.20:5556/userinfo
-    ProxyPass /keys http://172.25.1.20:5556/keys
-    ProxyPassReverse /keys http://172.25.1.20:5556/keys
+    # Proxy everything to Dex with service name
+    ProxyPass /static/ http://dex-server:5556/static/
+    ProxyPassReverse /static/ http://dex-server:5556/static/
+    ProxyPass /theme/ http://dex-server:5556/theme/
+    ProxyPassReverse /theme/ http://dex-server:5556/theme/
+    ProxyPass /.well-known/ http://dex-server:5556/.well-known/
+    ProxyPassReverse /.well-known/ http://dex-server:5556/.well-known/
+    ProxyPass /auth http://dex-server:5556/auth
+    ProxyPassReverse /auth http://dex-server:5556/auth
+    ProxyPass /token http://dex-server:5556/token
+    ProxyPassReverse /token http://dex-server:5556/token
+    ProxyPass /userinfo http://dex-server:5556/userinfo
+    ProxyPassReverse /userinfo http://dex-server:5556/userinfo
+    ProxyPass /keys http://dex-server:5556/keys
+    ProxyPassReverse /keys http://dex-server:5556/keys
     
     # Add security headers for OAuth endpoints with proper network access
     <Location ~ "/(auth|\.well-known|token|userinfo|keys|static|theme)">
@@ -88,17 +88,17 @@ TypesConfig conf/mime.types
         ProxyPreserveHost On
         Header always set X-Forwarded-Proto "http"
         Header always set X-Forwarded-Port "80"
-        Header always set X-Forwarded-Host "172.25.0.30"
+        Header always set X-Forwarded-Host "apache-reverse-proxy"
         Header always set X-CSRF-Token "required"
         
         # Additional CORS for OAuth endpoints
-        Header always set Access-Control-Allow-Origin "http://172.25.0.40"
+        Header always set Access-Control-Allow-Origin "http://pep"
         Header always set Access-Control-Allow-Credentials "true"
     </Location>
     
-    # Default redirect to OAuth2 PEP with IP-based redirect
+    # Default redirect to OAuth2 PEP with service name
     RewriteEngine On
-    RewriteRule ^/?$ http://172.25.0.40/ [R=302,L]
+    RewriteRule ^/?$ http://pep/ [R=302,L]
     
     # Health check - allow from internal networks
     <Location /health>

--- a/dex/config.yaml
+++ b/dex/config.yaml
@@ -1,11 +1,11 @@
-issuer: http://172.25.0.30
+issuer: http://apache-reverse-proxy
 
 storage:
   type: memory
 
 web:
   http: 0.0.0.0:5556
-  allowedOrigins: ['http://172.25.0.30', 'http://172.25.0.40']
+  allowedOrigins: ['http://apache-reverse-proxy', 'http://pep']
 
 logger:
   level: "debug"
@@ -18,17 +18,17 @@ oauth2:
 staticClients:
 - id: flask-app
   redirectURIs:
-  - 'http://172.25.0.40/oauth2callback'
+  - 'http://pep/oauth2callback'
   name: 'Flask Application (Apache OAuth2 PEP)'
   secret: flask-app-secret
-  trustedPeers: ['http://172.25.0.40']
+  trustedPeers: ['http://pep']
 
 connectors:
 - type: ldap
   id: ldap
   name: LDAP
   config:
-    host: 172.25.1.10:389
+    host: ldap-server:389
     insecureNoSSL: true
     insecureSkipVerify: true
     

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - "636"   # Internal LDAPS port only
     networks:
       backend-network:
-        ipv4_address: 172.25.1.10
+        # ipv4_address: 172.25.1.10
 
   dex:
     build: ./dex
@@ -40,7 +40,7 @@ services:
       - openldap
     networks:
       backend-network:
-        ipv4_address: 172.25.1.20
+        # ipv4_address: 172.25.1.20
 
   apache-proxy:
     build: ./apache-proxy
@@ -51,9 +51,9 @@ services:
       - dex
     networks:
       external-network:
-        ipv4_address: 172.25.0.30
+        # ipv4_address: 172.25.0.30
       backend-network:
-        ipv4_address: 172.25.1.30
+        # ipv4_address: 172.25.1.30
 
   pep:
     build: ./PEP
@@ -65,11 +65,11 @@ services:
       - flask-app
     networks:
       external-network:
-        ipv4_address: 172.25.0.40
+        # ipv4_address: 172.25.0.40
       backend-network:
-        ipv4_address: 172.25.1.40
+        # ipv4_address: 172.25.1.40
       app-network:
-        ipv4_address: 172.25.2.40
+        # ipv4_address: 172.25.2.40
 
   flask-app:
     build: ./flask-app
@@ -83,7 +83,7 @@ services:
       - openldap
     networks:
       app-network:
-        ipv4_address: 172.25.2.50
+        # ipv4_address: 172.25.2.50
 
 networks:
   # External/DMZ Network - Front-facing services


### PR DESCRIPTION
Migrate all inter-service communication from static IP addresses to Docker service names to enhance portability and simplify network management.

This change removes hardcoded `ipv4_address` assignments in `docker-compose.yml` and updates all service configurations (Dex, PEP, Apache proxy) and documentation to use Docker's internal DNS resolution via service names. This improves the maintainability and flexibility of the application by leveraging Docker's native networking capabilities.

---
<a href="https://cursor.com/background-agent?bcId=bc-0e1a0ee3-283f-484a-9d29-849146724d25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0e1a0ee3-283f-484a-9d29-849146724d25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>