### PR TITLE
Ajouter DNS pour corriger les redirections et vérifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,14 @@ The backend network configuration `internal: true` in docker-compose.yml ensures
 - [ACCESS_GUIDE.md](ACCESS_GUIDE.md): Instructions for running the project and logging in.
 - [NETWORK_ARCHITECTURE.md](NETWORK_ARCHITECTURE.md): Overview of the network segmentation.
 - [PRESENTATION.md](PRESENTATION.md): High-level overview of the project architecture and security features. 
+
+## Internal DNS Service
+
+An internal DNS service (Bind9) is now included in the stack. It resolves project service names (e.g., ldap.idp.local, dex.idp.local, apache.idp.local, pep.idp.local, flask.idp.local) to their respective internal IPs. All containers are configured to use this DNS for name resolution.
+
+- **DNS server IP:** 172.25.1.2
+- **Domain:** idp.local
+- **Zone file:** `dns/zones/db.internal`
+- **Configuration:** `dns/config/named.conf.*`
+
+This allows you to use friendly names (e.g., `curl http://pep.idp.local:80/`) instead of IP addresses for inter-container communication and testing. 

--- a/dns/config/named.conf.local
+++ b/dns/config/named.conf.local
@@ -1,0 +1,4 @@
+zone "idp.local" {
+    type master;
+    file "/var/lib/bind/db.internal";
+};

--- a/dns/config/named.conf.options
+++ b/dns/config/named.conf.options
@@ -1,0 +1,9 @@
+options {
+    directory "/var/cache/bind";
+    recursion yes;
+    allow-query { 172.25.0.0/16; 127.0.0.1; };
+    forwarders { };
+    dnssec-validation no;
+    listen-on { any; };
+    listen-on-v6 { none; };
+};

--- a/dns/zones/db.internal
+++ b/dns/zones/db.internal
@@ -1,0 +1,15 @@
+$TTL    604800
+@       IN      SOA     ns.idp.local. root.idp.local. (
+                              2         ; Serial
+                         604800         ; Refresh
+                          86400         ; Retry
+                        2419200         ; Expire
+                         604800 )       ; Negative Cache TTL
+;
+@       IN      NS      ns.idp.local.
+ns      IN      A       172.25.1.2
+ldap    IN      A       172.25.1.10
+dex     IN      A       172.25.1.20
+apache  IN      A       172.25.0.30
+pep     IN      A       172.25.0.40
+flask   IN      A       172.25.2.50

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,20 @@
 services:
+  dns:
+    image: internetsystemsconsortium/bind9:9.18
+    container_name: dns-server
+    environment:
+      - BIND9_USER=root
+    ports:
+      - "53:53/udp"
+      - "53:53/tcp"
+    volumes:
+      - ./dns/config:/etc/bind
+      - ./dns/zones:/var/lib/bind
+    networks:
+      backend-network:
+        ipv4_address: 172.25.1.2
+    restart: unless-stopped
+
   openldap:
     build: ./LDAP
     container_name: ldap-server
@@ -27,6 +43,8 @@ services:
     networks:
       backend-network:
         ipv4_address: 172.25.1.10
+    dns:
+      - 172.25.1.2
 
   dex:
     build: ./dex
@@ -41,6 +59,8 @@ services:
     networks:
       backend-network:
         ipv4_address: 172.25.1.20
+    dns:
+      - 172.25.1.2
 
   apache-proxy:
     build: ./apache-proxy
@@ -54,6 +74,8 @@ services:
         ipv4_address: 172.25.0.30
       backend-network:
         ipv4_address: 172.25.1.30
+    dns:
+      - 172.25.1.2
 
   pep:
     build: ./PEP
@@ -70,6 +92,8 @@ services:
         ipv4_address: 172.25.1.40
       app-network:
         ipv4_address: 172.25.2.40
+    dns:
+      - 172.25.1.2
 
   flask-app:
     build: ./flask-app
@@ -84,6 +108,8 @@ services:
     networks:
       app-network:
         ipv4_address: 172.25.2.50
+    dns:
+      - 172.25.1.2
 
 networks:
   # External/DMZ Network - Front-facing services


### PR DESCRIPTION
Add an internal DNS service (Bind9) to resolve service names and fix redirection issues.

The existing setup lacked a proper name resolution mechanism for inter-container communication, leading to issues with service redirections. This PR introduces a dedicated DNS server within the Docker Compose stack, allowing services to communicate using friendly, resolvable names (e.g., `ldap.idp.local`) instead of hardcoded IP addresses.

---
<a href="https://cursor.com/background-agent?bcId=bc-32b3811c-6fab-4a08-b0d3-c7964f82f39a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-32b3811c-6fab-4a08-b0d3-c7964f82f39a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>